### PR TITLE
Fix shebang

### DIFF
--- a/git-gerrit
+++ b/git-gerrit
@@ -1,4 +1,4 @@
-#!/bin/python -B
+#!/usr/bin/python -B
 # -*- coding: utf-8 -*-
 
 import json


### PR DESCRIPTION
Not every system has /bin/python on my system I have /usr/bin/python.
It would be better to use /usr/bin/env python as a shebang but on Linux systems you can only have one argument in the shebang.